### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
-FROM golang:latest 
-RUN mkdir /app 
-ADD . /app/ 
-WORKDIR /app 
-RUN go get github.com/caffix/amass && go build -o main . 
-CMD ["/app/main"]
+FROM golang:alpine as build
+WORKDIR /go/src/github.com/caffix/amass
+COPY . .
+RUN apk --no-cache add git \
+  && go get -u -v golang.org/x/vgo \
+  && vgo install
+  
+FROM alpine:latest
+COPY --from=build /go/bin/amass /bin/amass 
+ENTRYPOINT ["/bin/amass"]


### PR DESCRIPTION
This PR aims to optimize Dockerfile for running `amass` in containers:
- Build `amass` in a separate build stage, then copy the binary to a more minimal container. [TLDR](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#use-multi-stage-builds) - smaller attack surface on the container & consume less disk space
- No need to `RUN mkdir /app` for a couple of reasons:
  - Every `RUN` directive creates a [layer](https://docs.docker.com/storage/storagedriver/). [TLDR](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers) - Minimize the number of layers to ensure the container is performant.
  - `WORKDIR /app` creates the directory if it doesn't exist and essentially changes directory into it (so that all subsequent operations take place inside `WORKDIR`).
- `ADD` and `COPY` are functionally similar, but `COPY` is generally preferred. [TLDR](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy) - `ADD` can have subtle surprises

See Docker's [Best Practices for Writing Dockerfiles](https://docs.docker.com/develop/develop-images/dockerfile_best-practices) guide for more/detailed information.